### PR TITLE
Improve Android TV UX: DPAD handling, menu navigation with safe WebView injection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "stream.zappr.tv"
         minSdk = 21
         targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.1"
         vectorDrawables {
             useSupportLibrary = true
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-feature
@@ -16,8 +16,10 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
+        android:enableOnBackInvokedCallback="true"
         android:usesCleartextTraffic="true"
-        android:theme="@style/Theme.Zappr">
+        android:theme="@style/Theme.Zappr"
+        tools:targetApi="33">
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/stream/zappr/tv/AndroidTVScripts.kt
+++ b/app/src/main/java/stream/zappr/tv/AndroidTVScripts.kt
@@ -1,0 +1,157 @@
+package stream.zappr.tv
+
+internal val ANDROID_TV_KEY_FILTER_JS = """
+    (function() {
+      if (window.__androidTvKeyFilterInstalled) {
+        console.log('androidtv: key filter already installed');
+        return;
+      }
+      window.__androidTvKeyFilterInstalled = true;
+      
+      console.log('androidtv: installing key filter');
+
+      window.__androidTvIsPlaying = false;
+      window.__androidTvMenuMode = false;
+      window.__androidTvGlobalUnblock = false;
+
+      var __androidTvVideo = null;
+
+      function findVideoElement() {
+        if (__androidTvVideo && document.contains(__androidTvVideo)) {
+          return __androidTvVideo;
+        }
+        var v = document.querySelector('video');
+        if (!v) {
+          console.log('androidtv: no <video> element found yet');
+          return null;
+        }
+        __androidTvVideo = v;
+        console.log('androidtv: video element found, src=', v.currentSrc || v.src || '(none)');
+        
+        function updatePlayingFlag() {
+          var playing = !v.paused && !v.ended;
+          window.__androidTvIsPlaying = playing;
+          console.log('androidtv: video state changed, isPlaying=', playing);
+        }
+
+        v.addEventListener('play', updatePlayingFlag);
+        v.addEventListener('pause', updatePlayingFlag);
+        v.addEventListener('ended', updatePlayingFlag);
+        v.addEventListener('loadeddata', updatePlayingFlag);
+        v.addEventListener('loadedmetadata', updatePlayingFlag);
+
+        updatePlayingFlag();
+        return v;
+      }
+
+      // primo tentativo
+      findVideoElement();
+
+      // se ricreano il player al cambio canale, lo ritroviamo
+      var mo = new MutationObserver(function() {
+        findVideoElement();
+      });
+      try {
+        mo.observe(document.documentElement || document.body, {
+          childList: true,
+          subtree: true
+        });
+      } catch (err) {
+        console.log('androidtv: MutationObserver error', err && err.message);
+      }
+
+      document.addEventListener('keydown', function(e) {
+        var key = e.key || '';
+        var code = e.keyCode || e.which;
+
+        var target = e.target || {};
+        var active = document.activeElement || {};
+
+        var isUp    = key === 'ArrowUp'    || key === 'Up'    || code === 38;
+        var isDown  = key === 'ArrowDown'  || key === 'Down'  || code === 40;
+        var isEnter = key === 'Enter'      || code === 13;
+        var isBack  = key === 'Backspace'  || key === 'Escape' || code === 8 || code === 27;
+
+        var isLeft  = key === 'ArrowLeft'  || key === 'Left'  || code === 37;
+        var isRight = key === 'ArrowRight' || key === 'Right' || code === 39;
+
+        try {
+          console.log(
+            'androidtv: keydown',
+            'key=', key,
+            'code=', code,
+            'target=', target.tagName, target.className,
+            'active=', active.tagName, active.className,
+            'isPlaying=', window.__androidTvIsPlaying,
+            'menuMode=', window.__androidTvMenuMode,
+            'globalUnblock=', window.__androidTvGlobalUnblock
+          );
+        } catch (err) {}
+
+        // 1) BACK → abilita "tutto libero" (menu alternativo)
+        if (isBack) {
+          if (!window.__androidTvGlobalUnblock) {
+            window.__androidTvGlobalUnblock = true;
+            console.log('androidtv: GLOBAL UNBLOCK enabled due to Back');
+          }
+          // non blocchiamo mai Back
+          return;
+        }
+
+        // se siamo in globalUnblock, da qui in poi non blocchiamo più nulla
+        if (window.__androidTvGlobalUnblock) {
+          if (isLeft || isRight) {
+            console.log('androidtv: LEFT/RIGHT allowed (globalUnblock=true)');
+          }
+          return;
+        }
+
+        // 2) gestione menu principale (overlay)
+        // entra in menuMode: video in play + frecce verticali
+        if (!window.__androidTvMenuMode &&
+            window.__androidTvIsPlaying &&
+            (isUp || isDown)) {
+          window.__androidTvMenuMode = true;
+          console.log('androidtv: ENTER menu mode, reason=', key);
+        }
+        // esci da menuMode: mentre sei in menu, premi RIGHT o ENTER
+        else if (window.__androidTvMenuMode &&
+                 (isRight || isEnter)) {
+          window.__androidTvMenuMode = false;
+          console.log('androidtv: EXIT menu mode, reason=', key);
+          // lasciamo passare questo evento al sito
+          return;
+        }
+
+        // 3) filtro LEFT/RIGHT
+
+        if (!isLeft && !isRight) {
+          // non ci interessa altro
+          return;
+        }
+
+        // se siamo in menuMode, non blocchiamo le frecce orizzontali
+        if (window.__androidTvMenuMode) {
+          console.log('androidtv: LEFT/RIGHT allowed (menuMode=true)');
+          return;
+        }
+
+        // se il video non sta riproducendo, non blocchiamo
+        if (!window.__androidTvIsPlaying) {
+          console.log('androidtv: LEFT/RIGHT allowed (not playing)');
+          return;
+        }
+
+        // video in play, menuMode=false, globalUnblock=false → blocchiamo seek del player
+        e.preventDefault();
+        e.stopPropagation();
+        try {
+          console.log(
+            'androidtv: BLOCKED',
+            (isLeft ? 'LEFT' : 'RIGHT'),
+            'while video is playing and menuMode=false'
+          );
+        } catch (err) {}
+      }, true);
+    })();
+""".trimIndent()

--- a/app/src/main/java/stream/zappr/tv/MainActivity.kt
+++ b/app/src/main/java/stream/zappr/tv/MainActivity.kt
@@ -1,32 +1,133 @@
 package stream.zappr.tv
 
+import android.annotation.SuppressLint
 import android.os.Bundle
+import android.util.Log
+import android.view.KeyEvent
+import android.webkit.ConsoleMessage
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
 
-
 class MainActivity : AppCompatActivity() {
+
     private lateinit var webView: WebView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
 
-        webView = findViewById<WebView>(R.id.webView)
-        webView.webViewClient = WebViewClient()
-        webView.settings.javaScriptEnabled = true
-        webView.settings.domStorageEnabled = true
-        webView.setInitialScale(140)
-        webView.settings.cacheMode = android.webkit.WebSettings.LOAD_DEFAULT
-        webView.settings.mixedContentMode = android.webkit.WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
-        webView.loadUrl("https://zappr.stream/?androidtv")
+        //WebView.setWebContentsDebuggingEnabled(true)
+
+        setContentView(R.layout.activity_main)
+        webView = findViewById(R.id.webView)
+
+        setupWebView()
+        setupBackHandling()
     }
-    override fun onBackPressed() {
-        if (webView.canGoBack()) {
-            webView.goBack()
-        } else {
-            super.onBackPressed()
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun setupWebView() {
+        with(webView.settings) {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            mediaPlaybackRequiresUserGesture = false
+            cacheMode = WebSettings.LOAD_DEFAULT
+            mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
         }
+
+        webView.apply {
+            isFocusable = true
+            isFocusableInTouchMode = true
+            requestFocus()
+            setInitialScale(130)
+
+            webViewClient = object : WebViewClient() {
+                override fun shouldOverrideUrlLoading(
+                    view: WebView?,
+                    request: WebResourceRequest?,
+                ): Boolean {
+                    return false
+                }
+
+                override fun onPageFinished(view: WebView?, url: String?) {
+                    super.onPageFinished(view, url)
+                    Log.d(TAG, "onPageFinished: $url")
+                    view?.let { injectAndroidTvKeyFilter(it) }
+                }
+            }
+
+            webChromeClient = object : WebChromeClient() {
+                override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {
+                    Log.d(
+                        "WebViewConsole",
+                        "${consoleMessage.messageLevel()} " +
+                            "@${consoleMessage.sourceId()}:${consoleMessage.lineNumber()} " +
+                            " -> ${consoleMessage.message()}"
+                    )
+                    return super.onConsoleMessage(consoleMessage)
+                }
+            }
+
+            loadUrl(ZAPPR_URL)
+        }
+    }
+
+    private fun setupBackHandling() {
+        onBackPressedDispatcher.addCallback(this) {
+            if (::webView.isInitialized && webView.canGoBack()) {
+                webView.goBack()
+            } else {
+                finish()
+            }
+        }
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (!::webView.isInitialized || currentFocus !== webView) {
+            return super.dispatchKeyEvent(event)
+        }
+
+        val keyCode = event.keyCode
+        Log.d(TAG, "dispatchKeyEvent: action=${event.action} keyCode=$keyCode")
+
+        if (event.isDpadOrEnter()) {
+            val handledByWebView = webView.dispatchKeyEvent(event)
+            Log.d(
+                TAG,
+                "dispatchKeyEvent: ${if (handledByWebView) "handled" else "NOT handled"} by WebView ($keyCode)"
+            )
+            if (handledByWebView) {
+                return true
+            }
+        }
+
+        return super.dispatchKeyEvent(event)
+    }
+
+    private fun KeyEvent.isDpadOrEnter(): Boolean =
+        when (keyCode) {
+            KeyEvent.KEYCODE_DPAD_UP,
+            KeyEvent.KEYCODE_DPAD_DOWN,
+            KeyEvent.KEYCODE_DPAD_LEFT,
+            KeyEvent.KEYCODE_DPAD_RIGHT,
+            KeyEvent.KEYCODE_DPAD_CENTER,
+            KeyEvent.KEYCODE_ENTER -> true
+            else -> false
+        }
+
+    private fun injectAndroidTvKeyFilter(webView: WebView) {
+        Log.d(TAG, "injectAndroidTvKeyFilter: evaluating JS")
+        webView.evaluateJavascript(ANDROID_TV_KEY_FILTER_JS) { value ->
+            Log.d(TAG, "injectAndroidTvKeyFilter: JS eval result=$value")
+        }
+    }
+
+    companion object {
+        private const val TAG = "ZapprTV"
+        private const val ZAPPR_URL = "https://zappr.stream/?androidtv"
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <WebView
         android:id="@+id/webView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:focusable="true"
+        android:focusableInTouchMode="true"/>
 
 </LinearLayout>


### PR DESCRIPTION
This PR fixes #2, improves Android TV support for the Zappr WebView client.

Main changes:
 • Cleaned up MainActivity to follow Android best practices and correct usability (back callback, DPAD dispatch, readability).
 • Added safe JavaScript injection for TV remote key filtering:
   Prevent LEFT/RIGHT seeking while video is playing, but allow normal navigation inside menus.
 • Moved the JS code into a dedicated Kotlin file for clarity.

Everything runs inside the WebView and stays isolated.

tested on CCwGTV4K codename: sabrina